### PR TITLE
Usage of .text() instead of .html() to prevent XSS

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -552,7 +552,7 @@ function doStuff()
     // we don't need to be secure
     url = url.replace("https://", "http://");
 
-    $("#url").html(url);
+    $("#url").text(url);
 
     var domain = url.split("/")[2];
 


### PR DESCRIPTION
In jQuery the use of .html() to set values or contents, may lead to DOM based XSS.

For example, on http://catz.thirdletter.com/, if the URL entered is &quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt; and the .html() function from jQuery is used to put the contents of the URL field somewhere, the contents inserted will be unsanitised and hence will lead to XSS. In this case, the XSS is quite harmless as it is self inflicted, however, it is worth noting that using the .html() jQuery function is insecure.

For further reading and information please see:

http://code.google.com/p/domxsswiki/wiki/jQuery

P.S. Love the work put into this project :)
